### PR TITLE
fix: updateSession doesn't update

### DIFF
--- a/packages/mongoose/src/index.ts
+++ b/packages/mongoose/src/index.ts
@@ -118,10 +118,14 @@ export function MongooseAdapter(uri: string): Adapter {
       return from<AdapterSession>(session)
     },
     async updateSession(data) {
-      const session = await SessionModel.findOneAndUpdate({
-        sessionToken: data.sessionToken,
-        expires: data.expires,
-      })
+      const session = await SessionModel.findOneAndUpdate(
+        {
+          sessionToken: data.sessionToken,
+        },
+        {
+          expires: data.expires,
+        }
+      );
       return from<AdapterSession>(session)
     },
     async deleteSession(sessionToken) {


### PR DESCRIPTION
The bug manifests with an error about duplicate key. The fix is to search by `sessionToken` and then update `expires`. This is in line with the official implementation for the mongo provider (found here: https://github.com/nextauthjs/next-auth/blob/main/packages/adapter-mongodb/src/index.ts#L240).

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: https://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## Reasoning 💡

<!--
What changes are being made? What feature/bug is being fixed here?

IMPORTANT: Which, if any, adapter is being affected? Or are you wanting to add
a new one?
 -->

## Checklist 🧢

<!-- Feel free cross items ( like this `~[] item~` ) if they're irrelevant to your changes.

To check an item, place an `x` in the box like so: `- [x] Documentation`. -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged

<!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

## Affected issues 🎟

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

If you write `"Fixes"` or `"Closes"` before the issue link like so:

```
Fixes #359
```

the connected issue will be automatically closed once the PR is merged and hence help with maintenance of the library 😊

-->
